### PR TITLE
Adding links to astroplan docs/source

### DIFF
--- a/astroplanapp/templates/index.html
+++ b/astroplanapp/templates/index.html
@@ -8,6 +8,12 @@
     <div class='col-md-6'>
       <h1>Target visibility <sup style="color: #ff5000;">beta</sup></h1>
 
+      <p>
+        Powered by <strong>astroplan</strong>. To learn about astroplan, visit
+        the <a href="http://astroplan.readthedocs.org/">docs</a> or the
+        <a href="https://github.com/astropy/astroplan">source code</a>.
+      </p>
+
       <form id='astroplan-form' action="plot-airmass" method="get">
         <div class="form-group">
           <label for="date">Date</label><br/>


### PR DESCRIPTION
For #5. Hey @barentsen -- think you could make a PR to astroplan with the `plot_altitude` function other devs can run the webapp locally?

cc @cdeil
